### PR TITLE
Fix typo in controlared directory message

### DIFF
--- a/controlared.sh
+++ b/controlared.sh
@@ -11,7 +11,7 @@
 ruta=$HOME/controlared
 #es un simple if para saber si existe o no la carpeta
 if [ ! -d $ruta ]; then
-echo "creando la carpeta controlared en el direcotrio home "
+echo "creando la carpeta controlared en el directorio home "
 mkdir $ruta
 #para ver si existe el archivo
 if [ -f $ruta/listablanca.txt ];


### PR DESCRIPTION
## Summary
- fix spelling of "directorio" in controlared creation message

## Testing
- `bash -n controlared.sh`


------
https://chatgpt.com/codex/tasks/task_e_6895c44f27f08330ba6bf5c4c3ed41bd