### PR TITLE
Fix shebang in login scripts

### DIFF
--- a/login_hackendefail.sh
+++ b/login_hackendefail.sh
@@ -1,4 +1,4 @@
-#/bin/bash
+#!/bin/bash
 unahoramenos=`date +%R --date='-1 hours'`
 horaactual=`date +%R`
 lastb -s $unahoramenos -t $horaactual | grep hackende > /tmp/loginfailshackende.txt

--- a/login_rootfail.sh
+++ b/login_rootfail.sh
@@ -1,4 +1,4 @@
-#/bin/bash
+#!/bin/bash
 unahoramenos=`date +%R --date='-1 hours'`
 horaactual=`date +%R`
 lastb -s $unahoramenos -t $horaactual | grep root > /tmp/loginfailsroot.txt


### PR DESCRIPTION
## Summary
- Correct shebang in `login_hackendefail.sh`
- Correct shebang in `login_rootfail.sh`

## Testing
- `bash -n login_hackendefail.sh login_rootfail.sh`


------
https://chatgpt.com/codex/tasks/task_e_6895c459c1848330bb25d2283dd7d391