### PR TITLE
Add system report script and backup cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
 # scripts
 todo tipo de script útiles para linux
+
+## Scripts añadidos
+
+- `system_report.sh`: genera un informe del sistema mostrando uso de disco y memoria y avisa si el disco raíz supera un umbral.
+- `actualizar.sh`: ahora elimina automáticamente los backups antiguos. Se puede especificar la cantidad de días a conservar como primer parámetro (por defecto 7).

--- a/actualizar.sh
+++ b/actualizar.sh
@@ -1,8 +1,24 @@
 #!/bin/bash
 # -*- ENCODING: UTF-8 -*-
-sudo dnf update -y > /tmp/update.txt
+# Ejecuta "dnf update" y guarda un backup del log.
+# El primer parámetro permite especificar la cantidad de días a conservar backups (por defecto 7).
+
+retention_days=${1:-7}
+logfile="/tmp/update.txt"
+backupdir="/backupsscripts/backups_comandoupdate"
 fechahoy=$(date +"%d-%m-%Y")
-tar -zcvf backupsupdate.$fechahoy.tar.gz /tmp/update.txt
-cp backupsupdate.$fechahoy.tar.gz /backupsscripts/backups_comandoupdate
-rm -rf backupsupdate.$fechahoy.tar.gz
-rm -rf /tmp/update.txt
+
+# Ejecuta actualización y guarda el log
+sudo dnf update -y > "$logfile"
+
+# Crea backup comprimido del log
+archivo="backupsupdate.$fechahoy.tar.gz"
+tar -zcvf "$archivo" "$logfile"
+cp "$archivo" "$backupdir"
+rm -f "$archivo" "$logfile"
+
+# Limpia backups antiguos
+find "$backupdir" -type f -name "backupsupdate.*.tar.gz" -mtime +"$retention_days" -print -delete
+
+echo "Backup almacenado en $backupdir"
+echo "Se eliminarán backups con más de $retention_days días"

--- a/system_report.sh
+++ b/system_report.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# Generate a simple system status report including disk and memory usage.
+# If the root filesystem usage exceeds the optional threshold argument
+# (default 80 percent) a warning is printed.
+
+threshold=${1:-80}
+logfile="/tmp/system_report_$(date +"%Y%m%d_%H%M%S").log"
+
+{
+    echo "System report generated on $(date)"
+    echo "Hostname: $(hostname)"
+    echo
+    echo "Disk usage:";
+    df -h /
+    echo
+    echo "Memory usage:";
+    free -h
+    echo
+    echo "Top processes by memory:";
+    ps -eo pid,comm,%mem,%cpu --sort=-%mem | head
+} > "$logfile"
+
+used=$(df / | tail -1 | awk '{print $5}' | tr -d '%')
+if [ "$used" -ge "$threshold" ]; then
+    echo "WARNING: root filesystem at ${used}% used" >> "$logfile"
+fi
+
+cat "$logfile"
+echo "Report saved to $logfile"


### PR DESCRIPTION
## Summary
- add `system_report.sh` to capture disk, memory, and process information with optional warning threshold
- extend `actualizar.sh` to support log rotation and configurable backup retention

## Testing
- `bash -n actualizar.sh`
- `bash -n system_report.sh`
- `./system_report.sh 85`


------
https://chatgpt.com/codex/tasks/task_e_6895c4e6ef6483309145f07fd8e631f4